### PR TITLE
chore: migrate CI runner label to github-actions-runner-new

### DIFF
--- a/.github/workflows/build-test-and-publish-ce.yml
+++ b/.github/workflows/build-test-and-publish-ce.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build-and-test:
-    runs-on: self-hosted
+    runs-on: github-actions-runner-new
     strategy:
       fail-fast: false
       matrix:
@@ -50,7 +50,7 @@ jobs:
         if: always()
         run: docker system prune -af --volumes
   publish:
-    runs-on: self-hosted
+    runs-on: github-actions-runner-new
     needs: build-and-test
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
- The self-hosted runner is being decommissioned org-wide.
- Updates `runs-on: self-hosted` to `runs-on: github-actions-runner-new` in `build-test-and-publish-ce.yml` (2 jobs).

## Test plan
- CI on this PR runs the affected jobs on `github-actions-runner-new`.